### PR TITLE
Ensure UT pass on Java 10. #128

### DIFF
--- a/dubbo-spring-boot-parent/pom.xml
+++ b/dubbo-spring-boot-parent/pom.xml
@@ -26,6 +26,10 @@
         <zookeeper.version>3.4.9</zookeeper.version>
         <curator-framework.version>2.12.0</curator-framework.version>
         <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
+        <maven-jar.version>3.0.2</maven-jar.version>
+        <maven-compiler.version>3.6.0</maven-compiler.version>
+        <maven-source.version>3.0.1</maven-source.version>
+        <maven-enforcer.version>3.0.0-M1</maven-enforcer.version>
     </properties>
 
     <dependencyManagement>
@@ -174,6 +178,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar.version}</version>
                 <configuration>
                     <archive>
                         <addMavenDescriptor>true</addMavenDescriptor>
@@ -188,15 +193,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler.version}</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
-                    <parameters>true</parameters>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven-enforcer.version}</version>
                 <executions>
                     <execution>
                         <id>enforce-rules</id>
@@ -223,6 +229,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>


### PR DESCRIPTION
* Fix a couple of maven warnings when building from source, typically by specifying the plugin versions.
* Ensure UT can run under Java9/Java 10, #128 