### PR TITLE
fix web(false) is obsolete and replaced

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -121,7 +121,7 @@ public class DubboProviderDemo {
     public static void main(String[] args) {
 
         new SpringApplicationBuilder(DubboProviderDemo.class)
-                .web(false) // 非 Web 应用
+                .web(WebApplicationType.NONE) // 非 Web 应用
                 .run(args);
 
     }


### PR DESCRIPTION
In the spring boot program, web(false) is obsolete and replaced with web(webapplicationtype.none)