### PR TITLE
 Avoid inserting dubbo's properties whose values are not Strings

### DIFF
--- a/dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/dubbo/util/DubboUtils.java
+++ b/dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/dubbo/util/DubboUtils.java
@@ -128,7 +128,8 @@ public abstract class DubboUtils {
         for (Map.Entry<String, Object> entry : properties.entrySet()) {
             String propertyName = entry.getKey();
 
-            if (propertyName.startsWith(DUBBO_PREFIX + PROPERTY_NAME_SEPARATOR) && entry.getValue() != null) {
+            if (propertyName.startsWith(DUBBO_PREFIX + PROPERTY_NAME_SEPARATOR)
+                && entry.getValue() != null) {
                 dubboProperties.put(propertyName, entry.getValue().toString());
             }
 

--- a/dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/dubbo/util/DubboUtils.java
+++ b/dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/dubbo/util/DubboUtils.java
@@ -130,7 +130,7 @@ public abstract class DubboUtils {
             String propertyName = entry.getKey();
 
             if (propertyName.startsWith(DUBBO_PREFIX + PROPERTY_NAME_SEPARATOR)) {
-                dubboProperties.put(propertyName, entry.getValue());
+                dubboProperties.put(propertyName, entry.getValue().toString());
             }
 
         }

--- a/dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/dubbo/util/DubboUtils.java
+++ b/dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/dubbo/util/DubboUtils.java
@@ -16,12 +16,11 @@
  */
 package com.alibaba.boot.dubbo.util;
 
-import org.springframework.core.env.ConfigurableEnvironment;
-
 import java.util.Collections;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import org.springframework.core.env.ConfigurableEnvironment;
 
 /**
  * The utilities class for Dubbo
@@ -129,7 +128,7 @@ public abstract class DubboUtils {
         for (Map.Entry<String, Object> entry : properties.entrySet()) {
             String propertyName = entry.getKey();
 
-            if (propertyName.startsWith(DUBBO_PREFIX + PROPERTY_NAME_SEPARATOR)) {
+            if (propertyName.startsWith(DUBBO_PREFIX + PROPERTY_NAME_SEPARATOR) && entry.getValue() != null) {
                 dubboProperties.put(propertyName, entry.getValue().toString());
             }
 

--- a/dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/dubbo/util/EnvironmentUtils.java
+++ b/dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/dubbo/util/EnvironmentUtils.java
@@ -73,7 +73,7 @@ public abstract class EnvironmentUtils {
                 for (String propertyName : propertyNames) {
 
                     if (!properties.containsKey(propertyName)) { // put If absent
-                        properties.put(propertyName, propertySource.getProperty(propertyName).toString());
+                        properties.put(propertyName, propertySource.getProperty(propertyName));
                     }
 
                 }

--- a/dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/dubbo/util/EnvironmentUtils.java
+++ b/dubbo-spring-boot-autoconfigure/src/main/java/com/alibaba/boot/dubbo/util/EnvironmentUtils.java
@@ -73,7 +73,7 @@ public abstract class EnvironmentUtils {
                 for (String propertyName : propertyNames) {
 
                     if (!properties.containsKey(propertyName)) { // put If absent
-                        properties.put(propertyName, propertySource.getProperty(propertyName));
+                        properties.put(propertyName, propertySource.getProperty(propertyName).toString());
                     }
 
                 }


### PR DESCRIPTION
The action `ConfigUtils.getProperties().putAll(dubboProperties) ` will put values that not strings into dubbo's properties.