### PR TITLE
correct dubbo-spring-boot-starter pom configuration

### DIFF
--- a/dubbo-spring-boot-starter/pom.xml
+++ b/dubbo-spring-boot-starter/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <scope>true</scope>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Dubbo -->


### PR DESCRIPTION
```
<dependency>
   <groupId>org.springframework.boot</groupId>
   <artifactId>spring-boot-starter</artifactId>
   <scope>true</scope>
</dependency>
```
`<scope>true</scope>` i think it should be `<scope>provided</scope>`