### PR TITLE
Fix build failure

### DIFF
--- a/dubbo-spring-boot-samples/dubbo-registry-nacos-samples/consumer-sample/pom.xml
+++ b/dubbo-spring-boot-samples/dubbo-registry-nacos-samples/consumer-sample/pom.xml
@@ -21,7 +21,8 @@
     <parent>
         <artifactId>dubbo-spring-boot-registry-nacos-samples</artifactId>
         <groupId>org.apache.dubbo.samples</groupId>
-        <version>2.7.1</version>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Fix build failure, error message:
```
[FATAL] Non-resolvable parent POM for org.apache.dubbo.samples:dubbo-spring-boot-registry-nacos-consumer-sample:[unknown-version]: Failure to find org.apache.dubbo.samples:dubbo-spring-boot-registry-nacos-samples:pom:2.7.1 in http://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced and 'parent.relativePath' points at wrong local POM @ line 21, column 13
 @ 
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project org.apache.dubbo.samples:dubbo-spring-boot-registry-nacos-consumer-sample:[unknown-version] (/home/travis/build/biyuhao/incubator-dubbo-spring-boot-project/dubbo-spring-boot-samples/dubbo-registry-nacos-samples/consumer-sample/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for org.apache.dubbo.samples:dubbo-spring-boot-registry-nacos-consumer-sample:[unknown-version]: Failure to find org.apache.dubbo.samples:dubbo-spring-boot-registry-nacos-samples:pom:2.7.1 in http://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced and 'parent.relativePath' points at wrong local POM @ line 21, column 13 -> [Help 2]
```
replace const version with `${revision}`