### PR TITLE
fix costyle squid:S1161

### DIFF
--- a/dubbo-spring-boot-autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/DubboRelaxedBinding2AutoConfiguration.java
+++ b/dubbo-spring-boot-autoconfigure/src/main/java/org/apache/dubbo/spring/boot/autoconfigure/DubboRelaxedBinding2AutoConfiguration.java
@@ -55,6 +55,7 @@ public class DubboRelaxedBinding2AutoConfiguration {
     @Bean(name = BASE_PACKAGES_PROPERTY_RESOLVER_BEAN_NAME)
     public PropertyResolver dubboScanBasePackagesPropertyResolver(ConfigurableEnvironment environment) {
         ConfigurableEnvironment propertyResolver = new AbstractEnvironment() {
+            @Override
             protected void customizePropertySources(MutablePropertySources propertySources) {
                 Map<String, Object> dubboScanProperties = PropertySourcesUtils.getSubProperties(environment, DUBBO_SCAN_PREFIX);
                 propertySources.addLast(new MapPropertySource("dubboScanProperties", dubboScanProperties));

--- a/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/env/DubboDefaultPropertiesEnvironmentPostProcessor.java
+++ b/dubbo-spring-boot-compatible/autoconfigure/src/main/java/org/apache/dubbo/spring/boot/env/DubboDefaultPropertiesEnvironmentPostProcessor.java
@@ -70,7 +70,7 @@ public class DubboDefaultPropertiesEnvironmentPostProcessor implements Environme
     }
 
     private Map<String, Object> createDefaultProperties(ConfigurableEnvironment environment) {
-        Map<String, Object> defaultProperties = new HashMap<String, Object>();
+        Map<String, Object> defaultProperties = new HashMap<>();
         setDubboApplicationNameProperty(environment, defaultProperties);
         setDubboConfigMultipleProperty(defaultProperties);
         setDubboApplicationQosEnableProperty(defaultProperties);


### PR DESCRIPTION
"@Override" should be used on overriding and implementing methods
Major
squid:S1161
Using the @Override annotation is useful for two reasons :
It elicits a warning from the compiler if the annotated method doesn't actually override anything, as in the case of a misspelling.
It improves the readability of the source code by making it obvious that methods are overridden.